### PR TITLE
Settings shouldn't require all of them

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -6,7 +6,7 @@ export interface MiddlewareOptions {
   workspaceName?: string
   env?: any
   config?: any
-  settings?: ISettings
+  settings?: Partial<ISettings>
   schema?: IntrospectionResult
   tabs?: Tab[]
   codeTheme?: EditorColours


### PR DESCRIPTION
Right now the `ISettings` interface requires *all* of the settings, but it should be partial.

This will allow:
```ts
const settings: ISettings = {
  "request.credentials": "include"
}
```