### PR TITLE
Add Query Plan tab to Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ These are the settings currently available:
   'schema.polling.interval': 2000, // schema polling interval in ms
   'schema.disableComments': boolean,
   'tracing.hideTracingResponse': true,
+  'queryPlan.hideQueryPlanResponse': boolean
 }
 ```
 
@@ -108,6 +109,7 @@ interface ISettings {
   'schema.polling.interval': number
   'schema.disableComments': boolean
   'tracing.hideTracingResponse': boolean
+  'queryPlan.hideQueryPlanResponse': boolean
 }
 ```
 

--- a/packages/graphql-playground-html/package.json
+++ b/packages/graphql-playground-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-playground-html",
+  "name": "@apollographql/graphql-playground-html",
   "version": "1.6.13",
   "homepage": "https://github.com/graphcool/graphql-playground/tree/master/packages/graphql-playground-html",
   "description": "GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration).",

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -21,6 +21,7 @@ export interface ISettings {
   'editor.theme': Theme
   'editor.reuseHeaders': boolean
   'tracing.hideTracingResponse': boolean
+  'queryPlan.hideQueryPlanResponse': boolean
   'editor.fontSize': number
   'editor.fontFamily': string
   'request.credentials': string

--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-playground-react",
+  "name": "@apollographql/graphql-playground-react",
   "version": "1.7.20",
   "main": "./lib/lib.js",
   "typings": "./lib/lib.d.ts",

--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -110,6 +110,7 @@ export interface ReduxProps {
   schemaFetchingSuccess: (
     endpoint: string,
     tracingSupported: boolean,
+    isQueryPlanSupported: boolean,
     isPollingSchema: boolean,
   ) => void
   isReloadingSchema: boolean
@@ -276,6 +277,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
           this.props.schemaFetchingSuccess(
             data.endpoint,
             schema.tracingSupported,
+            schema.isQueryPlanSupported,
             props.isPollingSchema,
           )
           this.initialSchemaFetch = false

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -145,7 +145,7 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
   private httpHeadersRef
   private containerComponent
   private tracingRef
-  private queryPlannerRef
+  private queryPlanRef
 
   componentDidMount() {
     // Ensure a form of a schema exists (including `null`) and
@@ -271,7 +271,7 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
                   </ExtensionsDrawerSubtitle>
                   <ExtensionsDrawerSubtitle
                     isOpen={!this.props.isTracingActive}
-                    ref={this.setQueryPlannerRef}
+                    ref={this.setQueryPlanRef}
                     onClick={this.props.closeTracing}
                   >
                     Query Plan
@@ -315,8 +315,8 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
     this.httpHeadersRef = ref
   }
 
-  setQueryPlannerRef = ref => {
-    this.queryPlannerRef = ref
+  setQueryPlanRef = ref => {
+    this.queryPlanRef = ref
   }
 
   setTracingRef = ref => {
@@ -501,7 +501,7 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
     if (
       wasOpen &&
       (downEvent.target === this.tracingRef ||
-        downEvent.target === this.queryPlannerRef)
+        downEvent.target === this.queryPlanRef)
     ) {
       return
     }

--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -199,15 +199,15 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
                   isOpen={this.props.variableEditorOpen}
                   onMouseDown={this.handleVariableResizeStart}
                 >
-                  <VariableEditorSubtitle
-                    isOpen={this.props.queryVariablesActive}
+                  <DrawerTab
+                    isActive={this.props.queryVariablesActive}
                     ref={this.setQueryVariablesRef}
                     onClick={this.props.openQueryVariables}
                   >
                     Query Variables
-                  </VariableEditorSubtitle>
-                  <VariableEditorSubtitle
-                    isOpen={!this.props.queryVariablesActive}
+                  </DrawerTab>
+                  <DrawerTab
+                    isActive={!this.props.queryVariablesActive}
                     ref={this.setHttpHeadersRef}
                     onClick={this.props.closeQueryVariables}
                   >
@@ -215,7 +215,7 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
                       (this.props.headersCount && this.props.headersCount > 0
                         ? `(${this.props.headersCount})`
                         : '')}
-                  </VariableEditorSubtitle>
+                  </DrawerTab>
                 </VariableEditorTitle>
                 {this.props.queryVariablesActive ? (
                   <VariableEditorComponent
@@ -262,20 +262,20 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
                   isOpen={this.props.isExtensionsDrawerOpen}
                   onMouseDown={this.handleExtensionsDrawerResizeStart}
                 >
-                  <ExtensionsDrawerSubtitle
-                    isOpen={this.props.isTracingActive}
+                  <DrawerTab
+                    isActive={this.props.isTracingActive}
                     ref={this.setTracingRef}
                     onClick={this.props.openTracing}
                   >
                     Tracing
-                  </ExtensionsDrawerSubtitle>
-                  <ExtensionsDrawerSubtitle
-                    isOpen={!this.props.isTracingActive}
+                  </DrawerTab>
+                  <DrawerTab
+                    isActive={!this.props.isTracingActive}
                     ref={this.setQueryPlanRef}
                     onClick={this.props.closeTracing}
                   >
                     Query Plan
-                  </ExtensionsDrawerSubtitle>
+                  </DrawerTab>
                 </ExtensionsDrawerTitle>
                 {this.props.isTracingActive ? (
                   <ResponseTracing open={true} />
@@ -704,12 +704,6 @@ interface TitleProps {
 }
 
 const BottomDrawerTitle = styled.div`
-  background: #0b1924;
-  text-transform: uppercase;
-  font-weight: 600;
-  letter-spacing: 0.53px;
-  line-height: 14px;
-  font-size: 14px;
   padding: 14px 14px 15px 21px;
   user-select: none;
 `
@@ -735,18 +729,6 @@ const VariableEditorTitle = styled<TitleProps>(({ isOpen, ...rest }) => (
   background: ${p => p.theme.editorColours.leftDrawerBackground};
 `
 
-const VariableEditorSubtitle = styled<TitleProps, 'span'>('span')`
-  margin-right: 10px;
-  cursor: pointer;
-  color: ${p =>
-    p.isOpen
-      ? p.theme.editorColours.drawerText
-      : p.theme.editorColours.drawerTextInactive};
-  &:last-child {
-    margin-right: 0;
-  }
-`
-
 const ExtensionsDrawer = styled(BottomDrawer)`
   background: ${p => p.theme.editorColours.rightDrawerBackground};
 `
@@ -760,11 +742,24 @@ const ExtensionsDrawerTitle = styled<TitleProps>(({ isOpen, ...rest }) => (
   color: ${p => p.theme.editorColours.drawerTextInactive};
 `
 
-const ExtensionsDrawerSubtitle = styled<TitleProps, 'span'>('span')`
+interface DrawerTabProps {
+  onClick?: (e: Event) => void
+  onMouseDown?: (e: Event) => void
+  isActive: boolean
+  ref?: any
+}
+const DrawerTab = styled<DrawerTabProps, 'button'>('button')`
+  padding: 0;
   margin-right: 10px;
-  cursor: pointer;
+  background: #0b1924;
+
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.53px;
+  line-height: 14px;
+  font-size: 14px;
   color: ${p =>
-    p.isOpen
+    p.isActive
       ? p.theme.editorColours.drawerText
       : p.theme.editorColours.drawerTextInactive};
   &:last-child {

--- a/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react'
+import { connect } from 'react-redux'
+import { styled } from '../../styled'
+import { getQueryPlan } from '../../state/sessions/selectors'
+
+export interface Props {
+  value: string
+}
+
+export class QueryPlanViewer extends React.Component<Props, {}> {
+  private node: any
+  private viewer: any
+
+  componentDidMount() {
+    const CodeMirror = require('codemirror')
+    require('codemirror/addon/fold/foldgutter')
+    require('codemirror/addon/fold/brace-fold')
+    require('codemirror/addon/dialog/dialog')
+    require('codemirror/addon/search/search')
+    require('codemirror/addon/search/searchcursor')
+    require('codemirror/addon/search/jump-to-line')
+    require('codemirror/keymap/sublime')
+    require('codemirror-graphql/mode')
+
+    this.viewer = CodeMirror(this.node, {
+      lineWrapping: true,
+      value: this.props.value || '',
+      readOnly: true,
+      theme: 'graphiql',
+      mode: 'graphql',
+      keyMap: 'sublime',
+      foldGutter: {
+        minFoldSize: 4,
+      },
+      gutters: ['CodeMirror-foldgutter'],
+      extraKeys: {
+        // Persistent search box in Query Editor
+        'Cmd-F': 'findPersistent',
+        'Ctrl-F': 'findPersistent',
+
+        // Editor improvements
+        'Ctrl-Left': 'goSubwordLeft',
+        'Ctrl-Right': 'goSubwordRight',
+        'Alt-Left': 'goGroupLeft',
+        'Alt-Right': 'goGroupRight',
+      },
+    })
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.value !== nextProps.value
+  }
+
+  componentDidUpdate() {
+    const value = this.props.value || ''
+    this.viewer.setValue(value)
+  }
+
+  componentWillUnmount() {
+    this.viewer = null
+  }
+
+  setRef = ref => {
+    this.node = ref
+  }
+
+  /**
+   * Public API for retrieving the CodeMirror instance from this
+   * React component.
+   */
+  getCodeMirror() {
+    return this.viewer
+  }
+
+  /**
+   * Public API for retrieving the DOM client height for this component.
+   */
+  getClientHeight() {
+    return this.node && this.node.clientHeight
+  }
+
+  render() {
+    return <QueryPlanCodeMirror ref={this.setRef} />
+  }
+}
+
+const QueryPlanCodeMirror = styled('div')`
+  position: relative;
+  display: flex;
+  flex: 1;
+  height: 100%;
+
+  .CodeMirror {
+    height: 100%;
+    position: absolute;
+    box-sizing: border-box;
+    background: none;
+    padding-left: 38px;
+  }
+
+  .CodeMirror-cursor {
+    display: none !important;
+  }
+
+  .CodeMirror-scroll {
+    overflow: auto !important;
+    max-width: 50vw;
+    margin-right: 10px;
+  }
+
+  .CodeMirror-sizer {
+    margin-bottom: 0 !important;
+  }
+
+  .CodeMirror-lines {
+    margin: 20px 0;
+    padding: 0;
+  }
+
+  .cm-string {
+    color: ${p => p.theme.editorColours.property} !important;
+  }
+
+  // This is a hack to cover a couple holes in our "almost-graphql" representation
+  // of the Query Plan result
+  .cm-invalidchar {
+    color: rgba(255, 255, 255, 0.4);
+  }
+`
+
+export const QueryPlan = connect(state => ({
+  queryPlan: getQueryPlan(state),
+}))(
+  props =>
+    props.queryPlan ? <QueryPlanViewer value={props.queryPlan} /> : null,
+)

--- a/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
+++ b/packages/graphql-playground-react/src/components/Playground/SchemaFetcher.ts
@@ -110,6 +110,8 @@ export class SchemaFetcher {
     const headers = {
       ...parseHeaders(session.headers),
       'X-Apollo-Tracing': '1',
+      // Breaking the X- header pattern here since it's dated, and not
+      // recommended: https://www.mnot.net/blog/2009/02/18/x-
       'Apollo-Query-Plan-Experimental': '1',
     }
 

--- a/packages/graphql-playground-react/src/constants.ts
+++ b/packages/graphql-playground-react/src/constants.ts
@@ -149,8 +149,9 @@ export function getDefaultSession(endpoint: string) {
     editorFlex: 1,
     variableEditorOpen: false,
     variableEditorHeight: 200,
-    responseTracingOpen: false,
     responseTracingHeight: 300,
+    isExtensionsDrawerOpen: false,
+    isTracingActive: false,
     docExplorerWidth: 350,
     variableToType: Map({}),
     headers: '',
@@ -167,6 +168,7 @@ export function getDefaultSession(endpoint: string) {
     currentQueryEndTime: undefined,
     nextQueryStartTime: undefined,
     tracingSupported: undefined,
+    isQueryPlanSupported: undefined,
     changed: undefined,
     scrollTop: undefined,
   } as any

--- a/packages/graphql-playground-react/src/state/sessions/actions.ts
+++ b/packages/graphql-playground-react/src/state/sessions/actions.ts
@@ -16,6 +16,7 @@ export const {
   setVariableEditorHeight,
   setResponseTracingHeight,
   setTracingSupported,
+  setIsQueryPlanSupported,
   closeTracing,
   openTracing,
   closeVariables,
@@ -81,6 +82,7 @@ export const {
   SET_VARIABLE_EDITOR_HEIGHT: simpleAction('variableEditorHeight'),
   SET_RESPONSE_TRACING_HEIGHT: simpleAction('responceTracingHeight'),
   SET_TRACING_SUPPORTED: simpleAction('tracingSupported'),
+  SET_IS_QUERY_PLAN_SUPPORTED: simpleAction('isQueryPlanSupported'),
   SET_SUBSCRIPTION_ACTIVE: simpleAction('subscriptionActive'),
   SET_QUERY_TYPES: simpleAction('queryTypes'),
   SET_RESPONSE_EXTENSIONS: simpleAction('responseExtensions'),
@@ -91,21 +93,22 @@ export const {
   PRETTIFY_QUERY: simpleAction(),
   INJECT_HEADERS: (headers, endpoint) => ({ headers, endpoint }),
 
-  // setting multiple props
-  /*
+  /* setting multiple props
     this.setState({
-      responseTracingOpen: false,
-      responseTracingHeight: hadHeight,
+      isExtensionsDrawerOpen: true,
+      isTracingActive: false,
     } as State)
   */
-  CLOSE_TRACING: simpleAction('responseTracingHeight'),
-  OPEN_TRACING: simpleAction('responseTracingHeight'),
-  TOGGLE_TRACING: simpleAction(),
-  // setting multiple props
-  /*
+  // Action is intentionally ignoring arguments to prevent passing around
+  // React's `SyntheticEvent`s
+  CLOSE_TRACING: () => {},
+  OPEN_TRACING: () => {},
+  TOGGLE_TRACING: () => {},
+
+  /* setting multiple props
     this.setState({
-      responseTracingOpen: false,
-      responseTracingHeight: hadHeight,
+      variableEditorHeight: hadHeight,
+      variableEditorOpen: false,
     } as State)
   */
   CLOSE_VARIABLES: simpleAction('variableEditorHeight'),
@@ -131,9 +134,15 @@ export const {
   REFETCH_SCHEMA: simpleAction(),
   SET_ENDPOINT_UNREACHABLE: simpleAction('endpoint'),
   SET_SCROLL_TOP: (sessionId, scrollTop) => ({ sessionId, scrollTop }),
-  SCHEMA_FETCHING_SUCCESS: (endpoint, tracingSupported, isPollingSchema) => ({
+  SCHEMA_FETCHING_SUCCESS: (
     endpoint,
     tracingSupported,
+    isQueryPlanSupported,
+    isPollingSchema,
+  ) => ({
+    endpoint,
+    tracingSupported,
+    isQueryPlanSupported,
     isPollingSchema,
   }),
   /*

--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -124,9 +124,14 @@ function* runQuerySaga(action) {
   yield put(setSubscriptionActive(isSubscription(operation)))
   yield put(startQuery())
   let headers = parseHeaders(session.headers)
-  if (session.tracingSupported && session.responseTracingOpen) {
+  if (session.tracingSupported && session.isExtensionsDrawerOpen) {
     headers = set(headers, 'X-Apollo-Tracing', '1')
   }
+
+  if (session.isQueryPlanSupported && session.isExtensionsDrawerOpen) {
+    headers = set(headers, 'Apollo-Query-Plan-Experimental', '1')
+  }
+
   const lol = {
     endpoint: session.endpoint,
     headers,
@@ -184,12 +189,24 @@ function* runQuerySaga(action) {
       const { value, error } = yield take(channel)
       if (value && value.extensions) {
         const extensions = value.extensions
+
         yield put(setResponseExtensions(extensions))
         if (
           value.extensions.tracing &&
           settings['tracing.hideTracingResponse']
         ) {
           delete value.extensions.tracing
+        }
+
+        if (
+          value.extensions.__queryPlanExperimental &&
+          settings['queryPlan.hideQueryPlanResponse']
+        ) {
+          delete value.extensions.__queryPlanExperimental
+        }
+
+        if (value.extensions && Object.keys(value.extensions).length === 0) {
+          delete value.extensions
         }
       }
       const response = new ResponseRecord({

--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -129,6 +129,8 @@ function* runQuerySaga(action) {
   }
 
   if (session.isQueryPlanSupported && session.isExtensionsDrawerOpen) {
+    // Breaking the X- header pattern here since it's dated, and not
+    // recommended: https://www.mnot.net/blog/2009/02/18/x-
     headers = set(headers, 'Apollo-Query-Plan-Experimental', '1')
   }
 

--- a/packages/graphql-playground-react/src/state/sessions/reducers.ts
+++ b/packages/graphql-playground-react/src/state/sessions/reducers.ts
@@ -21,6 +21,7 @@ import {
   setResponseExtensions,
   setCurrentQueryStartTime,
   setCurrentQueryEndTime,
+  setIsQueryPlanSupported,
 } from './actions'
 import { getSelectedSessionId } from './selectors'
 import { getDefaultSession, defaultQuery } from '../../constants'
@@ -92,7 +93,8 @@ export class Session extends Record(getDefaultSession('')) {
   editorFlex: number
   variableEditorOpen: boolean
   variableEditorHeight: number
-  responseTracingOpen: boolean
+  isExtensionsDrawerOpen: boolean
+
   responseTracingHeight: number
   nextQueryStartTime?: Date
   tracingSupported?: boolean
@@ -200,6 +202,7 @@ const reducer = handleActions(
       setVariableEditorHeight,
       setResponseTracingHeight,
       setTracingSupported,
+      setIsQueryPlanSupported,
       setVariableToType,
       setOperations,
       setOperationName,
@@ -224,25 +227,33 @@ const reducer = handleActions(
           undefined,
         )
     },
-    CLOSE_TRACING: (state, { payload: { responseTracingHeight } }) => {
+    CLOSE_TRACING: (state /* { payload: { responseTracingHeight } } */) => {
       return state.mergeDeepIn(
         ['sessions', getSelectedSessionId(state)],
-        Map({ responseTracingHeight, responseTracingOpen: false }),
+        Map({
+          // responseTracingHeight,
+          isExtensionsDrawerOpen: true,
+          isTracingActive: false,
+        }),
+      )
+    },
+    OPEN_TRACING: (state /* { payload: { responseTracingHeight } } */) => {
+      return state.mergeDeepIn(
+        ['sessions', getSelectedSessionId(state)],
+        Map({
+          // responseTracingHeight,
+          isExtensionsDrawerOpen: true,
+          isTracingActive: true,
+        }),
       )
     },
     TOGGLE_TRACING: state => {
       const path = [
         'sessions',
         getSelectedSessionId(state),
-        'responseTracingOpen',
+        'isExtensionsDrawerOpen',
       ]
       return state.setIn(path, !state.getIn(path))
-    },
-    OPEN_TRACING: (state, { payload: { responseTracingHeight } }) => {
-      return state.mergeDeepIn(
-        ['sessions', getSelectedSessionId(state)],
-        Map({ responseTracingHeight, responseTracingOpen: true }),
-      )
     },
     CLOSE_VARIABLES: (state, { payload: { variableEditorHeight } }) => {
       return state.mergeDeepIn(

--- a/packages/graphql-playground-react/src/state/sessions/sagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/sagas.ts
@@ -24,6 +24,7 @@ import {
   setQueryTypes,
   refetchSchema,
   fetchSchema,
+  setIsQueryPlanSupported,
 } from './actions'
 import { getRootMap, getNewStack } from '../../components/Playground/util/stack'
 import { DocsSessionState } from '../docs/reducers'
@@ -145,6 +146,7 @@ function* fetchSchemaSaga() {
       schemaFetchingSuccess(
         session.endpoint,
         null,
+        null,
         yield select(getIsPollingSchema),
       ),
     )
@@ -163,6 +165,7 @@ function* refetchSchemaSaga() {
       schemaFetchingSuccess(
         session.endpoint,
         null,
+        null,
         yield select(getIsPollingSchema),
       ),
     )
@@ -180,7 +183,8 @@ function* renewStacks() {
   const fetchSession = yield getSessionWithCredentials()
   const docs: DocsSessionState = yield select(getSessionDocsState)
   const result = yield schemaFetcher.fetch(fetchSession)
-  const { schema, tracingSupported } = result
+  const { schema, tracingSupported, isQueryPlanSupported } = result
+
   if (schema && (!lastSchema || lastSchema !== schema)) {
     const rootMap = getRootMap(schema)
     const stacks = docs.navStack
@@ -188,6 +192,7 @@ function* renewStacks() {
       .filter(s => s)
     yield put(setStacks(session.id, stacks))
     yield put(setTracingSupported(tracingSupported))
+    yield put(setIsQueryPlanSupported(isQueryPlanSupported))
     lastSchema = schema
   }
 }

--- a/packages/graphql-playground-react/src/state/sessions/selectors.ts
+++ b/packages/graphql-playground-react/src/state/sessions/selectors.ts
@@ -93,13 +93,19 @@ export const getVariableEditorOpen = makeSessionSelector('variableEditorOpen')
 export const getVariableEditorHeight = makeSessionSelector(
   'variableEditorHeight',
 )
-export const getResponseTracingOpen = makeSessionSelector('responseTracingOpen')
+export const getIsExtensionsDrawerOpen = makeSessionSelector(
+  'isExtensionsDrawerOpen',
+)
+export const getIsTracingActive = makeSessionSelector('isTracingActive')
 export const getResponseTracingHeight = makeSessionSelector(
   'responseTracingHeight',
 )
 export const getDocExplorerWidth = makeSessionSelector('docExplorerWidth')
 export const getNextQueryStartTime = makeSessionSelector('nextQueryStartTime')
 export const getTracingSupported = makeSessionSelector('tracingSupported')
+export const getIsQueryPlanSupported = makeSessionSelector(
+  'isQueryPlanSupported',
+)
 
 function getSettings(state) {
   return state.getIn(['settingsString'])
@@ -175,6 +181,11 @@ export function getParsedVariablesFromSession(session) {
 export const getTracing = createSelector(
   [getResponseExtensions],
   extensions => extensions && extensions.tracing,
+)
+
+export const getQueryPlan = createSelector(
+  [getResponseExtensions],
+  extensions => extensions && extensions.__queryPlanExperimental,
 )
 
 export const getSessionsArray = createSelector([getSessionsState], state => {

--- a/packages/graphql-playground-react/src/state/workspace/reducers.ts
+++ b/packages/graphql-playground-react/src/state/workspace/reducers.ts
@@ -56,6 +56,7 @@ export const defaultSettings: ISettings = {
   'schema.polling.endpointFilter': '*localhost*',
   'schema.polling.interval': 2000,
   'tracing.hideTracingResponse': true,
+  'queryPlan.hideQueryPlanResponse': true,
 }
 
 // tslint:disable-next-line:max-classes-per-file

--- a/packages/graphql-playground-react/src/types.ts
+++ b/packages/graphql-playground-react/src/types.ts
@@ -32,4 +32,5 @@ export interface ISettings {
   ['schema.polling.endpointFilter']: string
   ['schema.polling.interval']: number
   ['tracing.hideTracingResponse']: boolean
+  ['queryPlan.hideQueryPlanResponse']: boolean
 }


### PR DESCRIPTION
This PR adds a new tab to the bottom right drawer to support Query Plan viewing. Support for this feature is currently being added to `apollo-gateway` in this PR: https://github.com/apollographql/apollo-platform-commercial/pull/85

This approach follows patterns established previously for supporting tracing.
* Send a toggle-able header `Apollo-Query-Plan-Experimental` to request this feature from the gateway
* Receive query plan from gateway via `response.extensions.__queryPlanExperimental`
* Display query plan in a separate pane, which lives in the same drawer as tracing
* Update the query plan whenever the user triggers a new request

![image](https://user-images.githubusercontent.com/29644393/57033755-99f1b600-6c02-11e9-93cf-aea2cbef40bf.png)

A couple TODOs here:
* Gateway will eventually want to send a JSON representation, rather than a printed version. We'll want to cutover to that once it's established.
* Currently, the printed version of the query plan _almost_ plays nice with a graphql parser. The result is a few stray invalid tokens within CodeMirror. I've covered those up with CSS for now. It's currently not worth the effort to write a parser just for this, especially since it may change.
* Making the extensions drawer resizeable proved to be troublesome, so I abandoned that for now (but left most of the code that handles that in place, with some things commented out). It's probably worth addressing at a later time for the sake of polish.
