### PR TITLE
Switch `hideQueryPlanResponse` from required to optional.

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -21,7 +21,7 @@ export interface ISettings {
   'editor.theme': Theme
   'editor.reuseHeaders': boolean
   'tracing.hideTracingResponse': boolean
-  'queryPlan.hideQueryPlanResponse': boolean
+  'queryPlan.hideQueryPlanResponse'?: boolean
   'editor.fontSize': number
   'editor.fontFamily': string
   'request.credentials': string


### PR DESCRIPTION
This maintains compatibility with existing implementations which use this
`ISettings` interface, which could be anyone who has provided their own
default settings to `playground` within Apollo Server.


Requesting a pull to apollographql:apollo from apollographql:abernix/make-type-optional

Write a message for this pull request. The first block
of text is the title and the rest is the description.