### PR TITLE
Add empty Query Plan tab state

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -271,19 +271,16 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
                   >
                     Tracing
                   </DrawerTab>
-                  {this.props.isQueryPlanSupported && (
-                    <DrawerTab
-                      isActive={!this.props.isTracingActive}
-                      ref={this.setQueryPlanRef}
-                      onClick={this.props.closeTracing}
-                    >
-                      Query Plan
-                    </DrawerTab>
-                  )}
+                  <DrawerTab
+                    isActive={!this.props.isTracingActive}
+                    ref={this.setQueryPlanRef}
+                    onClick={this.props.closeTracing}
+                  >
+                    Query Plan
+                  </DrawerTab>
                 </ExtensionsDrawerTitle>
-                {this.props.isTracingActive ||
-                !this.props.isQueryPlanSupported ? (
-                  <ResponseTracing open={true} />
+                {this.props.isTracingActive ? (
+                  <ResponseTracing />
                 ) : (
                   <QueryPlan />
                 )}

--- a/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { styled } from '../../styled'
-import { getQueryPlan } from '../../state/sessions/selectors'
+import {
+  getQueryPlan,
+  getIsQueryPlanSupported,
+} from '../../state/sessions/selectors'
 
 export interface Props {
   value: string
+  isQueryPlanSupported: boolean
 }
 
 export class QueryPlanViewer extends React.Component<Props, {}> {
@@ -80,7 +84,22 @@ export class QueryPlanViewer extends React.Component<Props, {}> {
   }
 
   render() {
-    return <QueryPlanCodeMirror ref={this.setRef} />
+    return this.props.isQueryPlanSupported ? (
+      <QueryPlanCodeMirror ref={this.setRef} />
+    ) : (
+      <NotSupported>
+        This GraphQL server either doesn’t support federation, or the query plan
+        extension is disabled. See the following page for instructions:<br />{' '}
+        <br />
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://www.apollographql.com/docs/apollo-server/federation/introduction"
+        >
+          Federation Introduction
+        </a>
+      </NotSupported>
+    )
   }
 }
 
@@ -128,9 +147,13 @@ const QueryPlanCodeMirror = styled('div')`
   }
 `
 
+const NotSupported = styled.div`
+  padding: 6px 25px 0;
+  font-size: 14px;
+  color: rgba(241, 143, 1, 1);
+`
+
 export const QueryPlan = connect(state => ({
-  queryPlan: getQueryPlan(state),
-}))(
-  props =>
-    props.queryPlan ? <QueryPlanViewer value={props.queryPlan} /> : null,
-)
+  value: getQueryPlan(state),
+  isQueryPlanSupported: getIsQueryPlanSupported(state),
+}))(QueryPlanViewer)

--- a/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/QueryPlan.tsx
@@ -88,16 +88,16 @@ export class QueryPlanViewer extends React.Component<Props, {}> {
       <QueryPlanCodeMirror ref={this.setRef} />
     ) : (
       <NotSupported>
-        This GraphQL server either doesn’t support federation, or the query plan
-        extension is disabled. See the following page for instructions:<br />{' '}
-        <br />
+        This GraphQL server either doesn't support Apollo Federation, or the
+        query plan extensions is disabled. See the{' '}
         <a
           target="_blank"
           rel="noopener noreferrer"
           href="https://www.apollographql.com/docs/apollo-server/federation/introduction"
         >
-          Federation Introduction
-        </a>
+          docs
+        </a>{' '}
+        for setting up query plan viewing with Apollo Federation.
       </NotSupported>
     )
   }

--- a/packages/graphql-playground-react/src/components/Playground/ResponseTracing.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ResponseTracing.tsx
@@ -110,16 +110,15 @@ class ResponseTracing extends React.PureComponent<ReduxProps> {
           </ReRun>
         ) : (
           <NotSupported>
-            This GraphQL server doesn’t support tracing. See the following page
-            for instructions:<br />
-            <br />
+            This GraphQL server doesn’t support tracing. See the{' '}
             <a
               target="_blank"
               rel="noopener noreferrer"
               href="https://github.com/apollographql/apollo-tracing"
             >
-              Apollo Tracing{' '}
-            </a>
+              Github page
+            </a>{' '}
+            for instructions.
           </NotSupported>
         )}
       </TracingWrapper>

--- a/packages/graphql-playground-react/src/components/Playground/ResponseTracing.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ResponseTracing.tsx
@@ -66,13 +66,9 @@ const TracingRows = styled.div`
   height: calc(100% + 116px);
 `
 
-interface Props {
-  open: boolean
-}
-
-class ResponseTracing extends React.PureComponent<ReduxProps & Props> {
+class ResponseTracing extends React.PureComponent<ReduxProps> {
   render() {
-    const { tracing, tracingSupported, startTime, endTime, open } = this.props
+    const { tracing, tracingSupported, startTime, endTime } = this.props
     const requestMs =
       tracing && startTime
         ? Math.abs(new Date(tracing.startTime).getTime() - startTime.getTime())
@@ -85,7 +81,7 @@ class ResponseTracing extends React.PureComponent<ReduxProps & Props> {
 
     return (
       <TracingWrapper>
-        {tracing && open ? (
+        {tracing ? (
           <TracingRows>
             <TracingRow
               path={['Request']}
@@ -116,7 +112,14 @@ class ResponseTracing extends React.PureComponent<ReduxProps & Props> {
           <NotSupported>
             This GraphQL server doesn’t support tracing. See the following page
             for instructions:<br />
-            https://github.com/apollographql/apollo-tracing
+            <br />
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/apollographql/apollo-tracing"
+            >
+              Apollo Tracing{' '}
+            </a>
           </NotSupported>
         )}
       </TracingWrapper>


### PR DESCRIPTION
* Add state to query plan pane when federation isn't
  supported. Link to docs.
* Use hrefs for links (in tracing pane)

![image](https://user-images.githubusercontent.com/29644393/58581712-0d3c1700-8205-11e9-95c4-41149cd73d85.png)

