### PR TITLE
 Use a `transparent` background for the `DrawerTab` component.

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -783,7 +783,7 @@ interface DrawerTabProps {
 const DrawerTab = styled<DrawerTabProps, 'button'>('button')`
   padding: 0;
   margin-right: 10px;
-  background: #0b1924;
+  background: transparent;
 
   text-transform: uppercase;
   font-weight: 600;


### PR DESCRIPTION
This will hopefully resolve an issue with the `light` theme which was
resulting in a dark background making it impossible to read the labels on
the components (e.g. "HTTP Headers" and "Query variables").

Fixes https://github.com/apollographql/apollo-server/issues/2979