### PR TITLE
Fix side tabs resize

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ExplorerTabs/SideTabs.tsx
@@ -6,6 +6,7 @@ import { getLeft } from 'graphiql/dist/utility/elementPosition'
 import {
   addStack,
   toggleDocs,
+  changeWidthDocs,
   changeKeyMove,
   setDocsVisible,
 } from '../../../state/docs/actions'
@@ -249,6 +250,7 @@ const mapDispatchToProps = dispatch =>
     {
       addStack,
       toggleDocs,
+      changeWidthDocs,
       changeKeyMove,
       setDocsVisible,
     },


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/2529.

Changes proposed in this pull request:

- Bind missing action `changeWidthDocs` so that the tabs can resize


@abernix 

Side not I also noticed an issue that occurs when:
- Resize small enough to close
- Keep holding mouse down and resize open
- Tab reopens with blank window

This is also occurring in prisma. Should I try to take care of this as well or want to just get this fix in?

![resize-while-holding-mouse-down-bug](https://user-images.githubusercontent.com/2586501/63642692-64c11600-c680-11e9-8c1e-0d59afdb1a90.gif)

