### PR TITLE
New feature: add html to head and/or body via RenderPageOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Including Fonts (`1.`)
 
 ```html
 <link
-	href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700"
+	href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700&display=swap"
 	rel="stylesheet"
 />
 ```

--- a/packages/graphql-playground-electron/src/renderer/index.html
+++ b/packages/graphql-playground-electron/src/renderer/index.html
@@ -5,7 +5,7 @@
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,500,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,500,700&display=swap" rel="stylesheet">
 
 </head>
 

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -60,7 +60,9 @@ export interface RenderPageOptions extends MiddlewareOptions {
   cdnUrl?: string
   env?: any
   title?: string
-  faviconUrl?: string | null
+  faviconUrl?: string | null,
+  htmlHeadAdditions?: string | null,
+  htmlBodyAdditions?: string | null
 }
 
 export interface Tab {
@@ -131,8 +133,10 @@ export function renderPlaygroundPage(options: RenderPageOptions) {
         ? ''
         : getCdnMarkup(extendedOptions)
     }
+    ${extendedOptions.htmlHeadAdditions || ''}
   </head>
   <body>
+    ${extendedOptions.htmlBodyAdditions || ''}
     <style type="text/css">
       html {
         font-family: "Open Sans", sans-serif;

--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -124,7 +124,7 @@ export function renderPlaygroundPage(options: RenderPageOptions) {
   <head>
     <meta charset=utf-8 />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700&display=swap" rel="stylesheet">
     <title>${extendedOptions.title || 'GraphQL Playground'}</title>
     ${
       extendedOptions.env === 'react' || extendedOptions.env === 'electron'

--- a/packages/graphql-playground-react/README.md
+++ b/packages/graphql-playground-react/README.md
@@ -73,7 +73,7 @@ The GraphQL Playground requires **React 16**.
 Including Fonts (`1.`)
 
 ```html
-<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700&display=swap" rel="stylesheet">
 ```
 
 Including stylesheet and the component (`2., 3.`)


### PR DESCRIPTION
Simply adds `htmlHeadAdditions?: string | null` and `htmlBodyAdditions?: string | null` to `RenderPageOptions` so that those of us using this in production can add content (e.g. tracking scripts) to the rendered GraphQL Playground when using apollo-server-express

Also adds async loading of fonts for slightly improved performance